### PR TITLE
Add link to source of workflow

### DIFF
--- a/.github/workflows/build_and_publish_image.yml
+++ b/.github/workflows/build_and_publish_image.yml
@@ -1,3 +1,4 @@
+# https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images
 name: Build and Publish Image
 
 # Configures this workflow to run every time a change is pushed to the branch called `release`.


### PR DESCRIPTION
Just trying out a workflow for incorporating changes from the `main` branch into the `release` branch as part of the release process.

Merging this PR should cause the 'Build and Publish Image' Actions workflow to run.